### PR TITLE
Added Blessing of the War Snapper support to buffMaintain

### DIFF
--- a/RELEASE/scripts/autoscend/auto_buff.ash
+++ b/RELEASE/scripts/autoscend/auto_buff.ash
@@ -222,6 +222,11 @@ boolean buffMaintain(effect buff, int mp_min, int casts, int turns, boolean spec
 		{
 			useSkill = $skill[Seek Out a Bird];
 		}																						break;
+	case $effect[Blessing of the War Snapper]:
+		if(auto_have_skill($skill[Blessing of the War Snapper]) && acquireTotem())
+		{
+			useSkill = $skill[Blessing of the War Snapper];
+		}																						break;					
 	case $effect[Blessing of Your Favorite Bird]:
 		if(auto_favoriteBirdCanSeek())
 		{


### PR DESCRIPTION
# Description

Adds support for 'Blessing of the War Snapper' to buffMaintain() which used in the Heavy Rains path for the final boss. Used the same method as support for Astral Shell already in the function.

Fixes loathers/autoscend#1470

## How Has This Been Tested?

Finished a Normal Heavy Rains Seal Clubber run (skill not permed)
Did a full Normal Heavy Rains Turtle Tamer run (skill bought)

## Checklist:

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have based my pull request against the [main branch](https://github.com/loathers/autoscend/tree/main) or have a good reason not to.
